### PR TITLE
Trying to resolve image pull error for hawkler metrics image.

### DIFF
--- a/roles/openshift_node_group/templates/node-config.yaml.j2
+++ b/roles/openshift_node_group/templates/node-config.yaml.j2
@@ -20,6 +20,8 @@ imageConfig:
   latest: false
 iptablesSyncPeriod: "{{ openshift_node_iptables_sync_period }}"
 kubeletArguments:
+  image-pull-progress-deadline:
+  - "10m"
 {% if openshift_is_atomic | bool %}
   volume-plugin-dir:
   - "/etc/origin/kubelet-plugins/volume/exec"


### PR DESCRIPTION
Recommended fix: https://access.redhat.com/solutions/4183691

Error:

Events:
  Type     Reason   Age                  From                             Message
  ----     ------   ----                 ----                             -------
  Warning  Failed   58m (x59 over 7h)    kubelet, oshnodeinfra-10-98 Error: ErrImagePull
  Normal   BackOff  14m (x1335 over 7h)  kubelet, oshnodeinfra-10-98  Back-off pulling image "quay.io/openshift/origin-metrics-hawkular-metrics:v3.11"
  Warning  Failed   9m (x66 over 7h)     kubelet, oshnodeinfra-10-98  Failed to pull image "quay.io/openshift/origin-metrics-hawkular-metrics:v3.11": rpc error: code = Canceled desc = context canceled
  Warning  Failed   4m (x1370 over 7h)   kubelet, oshnodeinfra-10-98  Error: ImagePullBackOff